### PR TITLE
Build docs with clean URLs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,4 +17,5 @@ build:
 
 sphinx:
   configuration: "docs/conf.py"
+  builder: "dirhtml"
   fail_on_warning: true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W -c .
+SPHINXOPTS    ?= -W -b dirhtml -c .
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
i.e. `contributor-guide/` instead of `contributor-guide/index.html`