### PR TITLE
Revert "Reduce frequency of runs of enforce-label action"

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -2,7 +2,7 @@ name: Enforce PR label
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened]
+    types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
   enforce-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts geojupyter/jupyter-xarray-tiler#25

Actually, we want these triggers. For example, if the PR fails the check on "open" event, then more commits are pushed, the check won't run and won't show up in the checks list. Reviewers would never be prompted to label -- the failed check doesn't "persist" forward when future events occur that don't require that check.

<!-- readthedocs-preview jupyter-xarray-tiler start -->
---
:mag: Docs preview: https://jupyter-xarray-tiler--26.org.readthedocs.build/en/26/

<!-- readthedocs-preview jupyter-xarray-tiler end -->