### PR TITLE
Disable trailing comma lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ select = ["ALL"]
 ignore = [
   "ANN002",  # Require type annotation for *args
   "ANN003",  # Require type annotation for **kwargs
+  "COM812",  # Require trailing commas (the Ruff formatter does this)
   "D",       # Require docstrings (TODO: Enable)
   "EM101",   # Forbit litereal strings in exception messages
   "EM102",   # Forbid f-strings in exception messages


### PR DESCRIPTION
This rule is handled by the Ruff formatter, so the lint rule is redundant. It is recommended to be disabled.

<!-- readthedocs-preview jupyter-xarray-tiler start -->
---
:mag: Docs preview: https://jupyter-xarray-tiler--27.org.readthedocs.build/en/27/

<!-- readthedocs-preview jupyter-xarray-tiler end -->