### PR TITLE
Make method names less repetitive

### DIFF
--- a/jupyter_xarray_tiler/_base_server.py
+++ b/jupyter_xarray_tiler/_base_server.py
@@ -47,12 +47,12 @@ class _FastApiTileServer(ABC):
             if isinstance(route, APIRoute)
         ]
 
-    async def start_tile_server(self) -> None:
+    async def start(self) -> None:
         """Start the tile server."""
         async with self._tile_server_lock:
             if self._tile_server_started.is_set():
                 return
-            self._tile_server_task = create_task(self._start_tile_server())
+            self._tile_server_task = create_task(self._start())
             await self._tile_server_started.wait()
 
     @abstractmethod
@@ -69,7 +69,7 @@ class _FastApiTileServer(ABC):
         """
         ...
 
-    async def stop_tile_server(self) -> None:
+    async def stop(self) -> None:
         """Stop the tile server."""
         task: Task[None] | None = None
         async with self._tile_server_lock:
@@ -81,7 +81,7 @@ class _FastApiTileServer(ABC):
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
 
-    async def _start_tile_server(self) -> None:
+    async def _start(self) -> None:
         self._app = self._init_fastapi_app()
 
         config = Config()

--- a/jupyter_xarray_tiler/tests/fixtures/api.py
+++ b/jupyter_xarray_tiler/tests/fixtures/api.py
@@ -9,7 +9,7 @@ from jupyter_xarray_tiler.xpublish import _get_server as _get_xpublish_server
 async def _reset_titiler_api_for_testing() -> None:
     # Shutdown the previous server
     server = _get_titiler_server()
-    await server.stop_tile_server()
+    await server.stop()
     # Clear the cache so next time we'll get a fresh one
     _get_titiler_server.cache_clear()
 
@@ -28,7 +28,7 @@ async def clean_titiler_api() -> AsyncGenerator[None]:
 async def _reset_xpublish_api_for_testing() -> None:
     # Shutdown the previous server
     server = _get_xpublish_server()
-    await server.stop_tile_server()
+    await server.stop()
     # Clear the cache so next time we'll get a fresh one
     _get_xpublish_server.cache_clear()
 

--- a/jupyter_xarray_tiler/tests/fixtures/server.py
+++ b/jupyter_xarray_tiler/tests/fixtures/server.py
@@ -9,18 +9,18 @@ from jupyter_xarray_tiler.xpublish._server import XpublishServer
 @pytest_asyncio.fixture
 async def clean_titiler_server() -> AsyncGenerator[TiTilerServer]:
     server = TiTilerServer()
-    await server.start_tile_server()
+    await server.start()
     yield server
 
-    await server.stop_tile_server()
+    await server.stop()
     del server
 
 
 @pytest_asyncio.fixture
 async def clean_xpublish_server() -> AsyncGenerator[XpublishServer]:
     server = XpublishServer()
-    await server.start_tile_server()
+    await server.start()
     yield server
 
-    await server.stop_tile_server()
+    await server.stop()
     del server

--- a/jupyter_xarray_tiler/tests/test_titiler_server.py
+++ b/jupyter_xarray_tiler/tests/test_titiler_server.py
@@ -72,7 +72,7 @@ class TestTiTilerServerRestart:
         assert clean_titiler_server._tile_server_started.is_set()
 
         with anyio.fail_after(5):
-            await clean_titiler_server.stop_tile_server()
+            await clean_titiler_server.stop()
 
         assert not clean_titiler_server._tile_server_started.is_set()
         assert clean_titiler_server._port is None
@@ -87,8 +87,8 @@ class TestTiTilerServerRestart:
         port_before_restart = clean_titiler_server._port
 
         with anyio.fail_after(5):
-            await clean_titiler_server.stop_tile_server()
-            await clean_titiler_server.start_tile_server()
+            await clean_titiler_server.stop()
+            await clean_titiler_server.start()
 
         assert clean_titiler_server._tile_server_started.is_set()
         assert clean_titiler_server._port != port_before_restart
@@ -109,7 +109,7 @@ class TestTiTilerServerRestart:
     ) -> None:
         """Test that tiles are accessible from a layer added after a restart."""
         with anyio.fail_after(5):
-            await clean_titiler_server.stop_tile_server()
+            await clean_titiler_server.stop()
 
         proxy_url = await clean_titiler_server.add_data_array(
             data_array=mock_data_array
@@ -119,9 +119,9 @@ class TestTiTilerServerRestart:
 
     @pytest.mark.asyncio
     async def test_stop_tile_server_does_not_hang_during_startup(self) -> None:
-        """Test stop_tile_server() doesn't block if called during startup."""
+        """Test stop() doesn't block if called during startup."""
         server = TiTilerServer()
 
         with anyio.fail_after(5):
-            await server.start_tile_server()
-            await server.stop_tile_server()
+            await server.start()
+            await server.stop()

--- a/jupyter_xarray_tiler/tests/test_xpublish_server.py
+++ b/jupyter_xarray_tiler/tests/test_xpublish_server.py
@@ -69,7 +69,7 @@ class TestXpublishServerRestart:
         assert clean_xpublish_server._tile_server_started.is_set()
 
         with anyio.fail_after(5):
-            await clean_xpublish_server.stop_tile_server()
+            await clean_xpublish_server.stop()
 
         assert not clean_xpublish_server._tile_server_started.is_set()
         assert clean_xpublish_server._port is None
@@ -84,8 +84,8 @@ class TestXpublishServerRestart:
         port_before_restart = clean_xpublish_server._port
 
         with anyio.fail_after(5):
-            await clean_xpublish_server.stop_tile_server()
-            await clean_xpublish_server.start_tile_server()
+            await clean_xpublish_server.stop()
+            await clean_xpublish_server.start()
 
         assert clean_xpublish_server._tile_server_started.is_set()
         assert clean_xpublish_server._port != port_before_restart
@@ -106,7 +106,7 @@ class TestXpublishServerRestart:
     ) -> None:
         """Test that tiles are accessible from a layer added after a restart."""
         with anyio.fail_after(5):
-            await clean_xpublish_server.stop_tile_server()
+            await clean_xpublish_server.stop()
 
         proxy_url = await clean_xpublish_server.add_data_array(
             data_array=mock_data_array,
@@ -117,9 +117,9 @@ class TestXpublishServerRestart:
 
     @pytest.mark.asyncio
     async def test_stop_tile_server_does_not_hang_during_startup(self) -> None:
-        """Test stop_tile_server() doesn't block if called during startup."""
+        """Test stop() doesn't block if called during startup."""
         server = XpublishServer()
 
         with anyio.fail_after(5):
-            await server.start_tile_server()
-            await server.stop_tile_server()
+            await server.start()
+            await server.stop()

--- a/jupyter_xarray_tiler/titiler/_server.py
+++ b/jupyter_xarray_tiler/titiler/_server.py
@@ -44,7 +44,7 @@ class TiTilerServer(_FastApiTileServer):
         algorithm: BaseAlgorithm | None = None,
         **kwargs: str | int,
     ) -> str:
-        await self.start_tile_server()
+        await self.start()
 
         if self._port is None:
             raise RuntimeError(f"{_not_initialized_message} {_found_bug_message}")

--- a/jupyter_xarray_tiler/xpublish/_server.py
+++ b/jupyter_xarray_tiler/xpublish/_server.py
@@ -42,7 +42,7 @@ class XpublishServer(_FastApiTileServer):
         rescale: tuple[float, float] | None = None,
         **kwargs: str | int,
     ) -> str:
-        await self.start_tile_server()
+        await self.start()
 
         if self._port is None:
             raise RuntimeError(f"{_not_initialized_message} {_found_bug_message}")


### PR DESCRIPTION


<!-- readthedocs-preview jupyter-xarray-tiler start -->
---
:mag: Docs preview: https://jupyter-xarray-tiler--54.org.readthedocs.build/en/54/

<!-- readthedocs-preview jupyter-xarray-tiler end -->