### PR TITLE
Add defensive timeout against startup hang

### DIFF
--- a/jupyter_xarray_tiler/_base_server.py
+++ b/jupyter_xarray_tiler/_base_server.py
@@ -52,8 +52,14 @@ class _FastApiTileServer(ABC):
         async with self._tile_server_lock:
             if self._tile_server_started.is_set():
                 return
+
             self._tile_server_task = create_task(self._start())
-            await self._tile_server_started.wait()
+            try:
+                with anyio.fail_after(30):
+                    await self._tile_server_started.wait()
+            except TimeoutError:
+                self._tile_server_task.cancel()
+                raise
 
     @abstractmethod
     async def add_data_array(


### PR DESCRIPTION
I'm uncomfortable with the infinite startup polling loop, let's make sure it doesn't go for more than 30s

<!-- readthedocs-preview jupyter-xarray-tiler start -->
---
:mag: Docs preview: https://jupyter-xarray-tiler--55.org.readthedocs.build/en/55/

<!-- readthedocs-preview jupyter-xarray-tiler end -->