### PR TITLE
Reset `self._tile_server_task` when resetting server state

### DIFF
--- a/jupyter_xarray_tiler/_base_server.py
+++ b/jupyter_xarray_tiler/_base_server.py
@@ -124,6 +124,7 @@ class _FastApiTileServer(ABC):
 
     def _reset_state(self) -> None:
         self._tile_server_started.clear()
+        self._tile_server_task = None
         self._port = None
         self._app = None
 


### PR DESCRIPTION
`self._tile_server_task` will reference the last finished task, and when the tile server is stopped, I think it makes more sense for this to reset to its initial state.

<!-- readthedocs-preview jupyter-xarray-tiler start -->
---
:mag: Docs preview: https://jupyter-xarray-tiler--56.org.readthedocs.build/en/56/

<!-- readthedocs-preview jupyter-xarray-tiler end -->