### PR TITLE
Rename Tasks, Events, Locks to be less repetitive

### DIFF
--- a/jupyter_xarray_tiler/_base_server.py
+++ b/jupyter_xarray_tiler/_base_server.py
@@ -27,9 +27,9 @@ class _FastApiTileServer(ABC):
     def __init__(self) -> None:
         self._app: FastAPI | None = None
         self._port: int | None = None
-        self._tile_server_task: Task[None] | None = None
-        self._tile_server_started = Event()
-        self._tile_server_lock = Lock()
+        self._task: Task[None] | None = None
+        self._started = Event()
+        self._lock = Lock()
 
     @property
     def routes(self) -> list[dict[str, Any]]:
@@ -49,16 +49,16 @@ class _FastApiTileServer(ABC):
 
     async def start(self) -> None:
         """Start the tile server."""
-        async with self._tile_server_lock:
-            if self._tile_server_started.is_set():
+        async with self._lock:
+            if self._started.is_set():
                 return
 
-            self._tile_server_task = create_task(self._start())
+            self._task = create_task(self._start())
             try:
                 with anyio.fail_after(30):
-                    await self._tile_server_started.wait()
+                    await self._started.wait()
             except TimeoutError:
-                self._tile_server_task.cancel()
+                self._task.cancel()
                 raise
 
     @abstractmethod
@@ -78,9 +78,9 @@ class _FastApiTileServer(ABC):
     async def stop(self) -> None:
         """Stop the tile server."""
         task: Task[None] | None = None
-        async with self._tile_server_lock:
-            if self._tile_server_started.is_set():
-                task = self._tile_server_task
+        async with self._lock:
+            if self._started.is_set():
+                task = self._task
 
         if task is not None:
             task.cancel()
@@ -115,7 +115,7 @@ class _FastApiTileServer(ABC):
                     except OSError:
                         await anyio.sleep(0.05)
                     else:
-                        self._tile_server_started.set()
+                        self._started.set()
                         break
 
         finally:
@@ -123,8 +123,8 @@ class _FastApiTileServer(ABC):
             self._reset_state()
 
     def _reset_state(self) -> None:
-        self._tile_server_started.clear()
-        self._tile_server_task = None
+        self._started.clear()
+        self._task = None
         self._port = None
         self._app = None
 

--- a/jupyter_xarray_tiler/tests/test_titiler_server.py
+++ b/jupyter_xarray_tiler/tests/test_titiler_server.py
@@ -68,13 +68,13 @@ class TestTiTilerServerRestart:
         self,
         clean_titiler_server: TiTilerServer,
     ) -> None:
-        """Test that _tile_server_started is cleared so the server can be restarted."""
-        assert clean_titiler_server._tile_server_started.is_set()
+        """Test that _started is cleared so the server can be restarted."""
+        assert clean_titiler_server._started.is_set()
 
         with anyio.fail_after(5):
             await clean_titiler_server.stop()
 
-        assert not clean_titiler_server._tile_server_started.is_set()
+        assert not clean_titiler_server._started.is_set()
         assert clean_titiler_server._port is None
         assert clean_titiler_server._app is None
 
@@ -90,7 +90,7 @@ class TestTiTilerServerRestart:
             await clean_titiler_server.stop()
             await clean_titiler_server.start()
 
-        assert clean_titiler_server._tile_server_started.is_set()
+        assert clean_titiler_server._started.is_set()
         assert clean_titiler_server._port != port_before_restart
 
     @pytest.mark.asyncio

--- a/jupyter_xarray_tiler/tests/test_xpublish_server.py
+++ b/jupyter_xarray_tiler/tests/test_xpublish_server.py
@@ -65,13 +65,13 @@ class TestXpublishServerRestart:
         self,
         clean_xpublish_server: XpublishServer,
     ) -> None:
-        """Test that _tile_server_started is cleared so the server can be restarted."""
-        assert clean_xpublish_server._tile_server_started.is_set()
+        """Test that _started is cleared so the server can be restarted."""
+        assert clean_xpublish_server._started.is_set()
 
         with anyio.fail_after(5):
             await clean_xpublish_server.stop()
 
-        assert not clean_xpublish_server._tile_server_started.is_set()
+        assert not clean_xpublish_server._started.is_set()
         assert clean_xpublish_server._port is None
         assert clean_xpublish_server._app is None
 
@@ -87,7 +87,7 @@ class TestXpublishServerRestart:
             await clean_xpublish_server.stop()
             await clean_xpublish_server.start()
 
-        assert clean_xpublish_server._tile_server_started.is_set()
+        assert clean_xpublish_server._started.is_set()
         assert clean_xpublish_server._port != port_before_restart
 
     @pytest.mark.asyncio


### PR DESCRIPTION


<!-- readthedocs-preview jupyter-xarray-tiler start -->
---
:mag: Docs preview: https://jupyter-xarray-tiler--57.org.readthedocs.build/en/57/

<!-- readthedocs-preview jupyter-xarray-tiler end -->