### PR TITLE
Add minimum bounds to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ keywords = [
 dynamic = ["version"]
 dependencies = [
     "jupyter_server>=2.4.0,<3",
-    "jupyter-server-proxy",
-    "anyio",
-    "anycorn",
-    "rioxarray",
-    "geopandas",
+    "jupyter-server-proxy>=4.4.0",
+    "anyio>=4.0",
+    "anycorn>=0.18.0",
+    "rioxarray>=0.19.0",
+    "geopandas>=1.0.0",
     "titiler-core>=1.1.1",
     "titiler-xarray>=1.1.1",
     "xpublish-tiles>=0.4.2",


### PR DESCRIPTION
Helps avoid "Dependency resolution exceeded maximum depth" errors in dependents

<!-- readthedocs-preview jupyter-xarray-tiler start -->
---
:mag: Docs preview: https://jupyter-xarray-tiler--62.org.readthedocs.build/en/62/

<!-- readthedocs-preview jupyter-xarray-tiler end -->