### PR TITLE
Disable uv cache for release workflow to avoid cache poisoning attack

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,10 @@ jobs:
           persist-credentials: false
 
       - uses: "astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39" # v8.2.0
+        with:
+          # Disable cache for release workflow only to avoid cache-poisoning attack
+          # See: <https://docs.zizmor.sh/audits/#cache-poisoning>
+          enable-cache: false
 
       - run: "uv build"
 


### PR DESCRIPTION


<!-- readthedocs-preview jupyter-tiler start -->
---
:mag: Docs preview: https://jupyter-tiler--71.org.readthedocs.build/en/71/

<!-- readthedocs-preview jupyter-tiler end -->